### PR TITLE
fix: auto-increment patch version for GitLab alpha releases

### DIFF
--- a/.github/workflows/gitlab-sdk-publish.yml
+++ b/.github/workflows/gitlab-sdk-publish.yml
@@ -23,15 +23,21 @@ jobs:
         env:
           REGISTRY: //gitlab.com/api/v4/projects/37663507/packages/npm/
       - run: |
-          # Get the base version from latest tag
-          BaseVersion=$(git describe --tags --abbrev=0)
-          echo "Base Version: $BaseVersion"
+          # Get the latest tag and increment patch version
+          LatestTag=$(git tag -l | sort -V | tail -1)
+          echo "Latest Tag: $LatestTag"
           
           # For release events, use the tag version
           if [[ "${{ github.event_name }}" == "release" ]]; then
-            Version=$BaseVersion
+            Version=${{ github.event.release.tag_name }}
           else
-            # For main/release branches, generate alpha version
+            # For main/release branches, increment patch version and add alpha suffix
+            # Extract major, minor, and patch version numbers
+            IFS='.' read -r major minor patch <<< "$LatestTag"
+            # Increment patch version
+            NextPatch=$((patch + 1))
+            BaseVersion="${major}.${minor}.${NextPatch}"
+            # Generate alpha version with timestamp
             Timestamp=$(date -u +%Y%m%d%H%M%S)
             Version="${BaseVersion}-alpha.${Timestamp}"
           fi


### PR DESCRIPTION
## Summary
Fix version generation logic for GitLab alpha releases to use correct version numbering.

## Problem
- `git describe --tags --abbrev=0` returns 1.2.6 instead of 2.4.5
- Alpha versions were using wrong base version (1.2.6-alpha.xxx)

## Solution
- Use `git tag -l | sort -V | tail -1` to get the latest version by semantic versioning
- Auto-increment patch version for alpha releases
- Alpha versions now use format: `latest_version+1-alpha.timestamp`
- Example: 2.4.5 → 2.4.6-alpha.YYYYMMDDHHmmss

## Result
- Before: 1.2.6-alpha.20250718114515
- After: 2.4.6-alpha.20250718120000